### PR TITLE
correctly detect R_COMPILED_BY

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-R_COMPILED_BY ?=-4.6.3
+R_COMPILED_BY ?= gcc-4.6.3
 PKG_CPPFLAGS=-I../windows/hunspell-1.3.3/include/hunspell
 PKG_LIBS=-L. -lparsers -L../windows/hunspell-1.3.3/lib${subst gcc ,-,${R_COMPILED_BY}}${R_ARCH} -lhunspell-1.3 -lRiconv
 


### PR DESCRIPTION
guessing that 'gcc' is missing from the test?
